### PR TITLE
Add package lsb-release

### DIFF
--- a/src/packages.txt
+++ b/src/packages.txt
@@ -31,3 +31,4 @@ redis-server
 nmap
 rsync
 kafkacat
+lsb-release


### PR DESCRIPTION
Provides the `lsb_release` util which comes in handy if we want to just copy & paste something from the internet like:

```
export GCSFUSE_REPO=gcsfuse-`lsb_release -c -s`
echo "deb http://packages.cloud.google.com/apt $GCSFUSE_REPO main" | sudo tee /etc/apt/sources.list.d/gcsfuse.list
curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
```

https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/docs/installing.md